### PR TITLE
Feat/add sample agent

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,21 @@ jobs:
         run: poetry install --no-interaction --no-ansi
       - name: Lint
         run: poetry run flake8
+  tests:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install poetry
+        run: pipx install poetry
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: poetry
+      - name: Install Packages
+        run: poetry install --no-interaction --no-ansi
+      - name: Run tests
+        run: poetry run pytest -v -s -W ignore::DeprecationWarning
   check-version:
     name: "Check version"
     runs-on: ubuntu-latest
@@ -63,7 +78,7 @@ jobs:
           package_manager: "poetry"
   publish:
     name: "Publish package"
-    needs: [preconditions, lint, dependency-check, tests, check-version]
+    needs: [preconditions, lint, tests, check-version]
     runs-on: ubuntu-latest
     # comment the line above to force publish
     if: ${{ needs.check-version.outputs.is_new_version == 'true' }}

--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@ The purpose of this repository is to allow interaction between nice-agent-portal
 The endpoints in this repository are:
 | endpoint | usage |
 |----------|----------|
-| "/send-query" | accepts query from Peer API, forwards it to Sample Agent & then to Veritable Peer |
-| "/webhooks/drpc"| accepts posts from veritable Cloudagent and passes them to PeerApi. These are either queries for peerApi or query responses for peer API |
-| "/receive-response" | This endpoint receives information from chainvine and passes it to Veritable as a response |
+| "/send-query" | Accepts query from Peer API, forwards it to Sample Agent & then to Veritable Peer. |
+| "/webhooks/drpc"| Accepts posts from veritable Cloudagent and passes them to PeerApi. These are either queries for peerApi or query responses for peer API. |
+| "/receive-response" | This endpoint receives information from chainvine and passes it to Veritable as a response. |
 
 ### Prerequisites:
 
-python 3.12 and higher and poetry installed
+- python 3.12 or higher
+- poetry installed
 
 ### To start the repo
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ for now `[202, {}]`
 {
   "jsonrpc": "string",
   "result": "string",
+  "error": {
+    "code": -32601,
+    "message": "string",
+    "data": "string"
+  },
   "id": "string"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ python 3.12 and higher and poetry installed
 
 Run `poetry install`
 
-cd into app directory and run `uvicorn main:app ` which starts the app with swagger interface on `http://0.0.0.0:8000/docs`.
+Some endpoints require interaction with fetch.ai agent. We have included such `SampleAgent` in this repo. In order to start it(in a new terminal window), please navigate to the `SampleAgent` directory and run: `python sampleAgent.py`. On startup agent prints it's own address -> please include this address in `core/config.py`
 
-Some endpoints require interaction with fetch.ai agent. We have included such `SampleAgent` in this repo. In order to start it(in a new terminal window), please navigate to the `SampleAgent` directory and run: `python sampleAgent.py`
+cd into app directory and run `uvicorn main:app ` which starts the app with swagger interface on `http://0.0.0.0:8000/docs`.
 
 ### To run tests run this:
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 The purpose of this repository is to allow interaction between nice-agent-portal (PEER API), Veritable Peer and Cambridge's 'intelligent agent'.
 
+### Envars
+
+Can be found in `core>config.py`.
+|ENV|required|default|
+|--|------|----------|
+|VERITABLE_URL|Y|http://localhost:3010|
+|PEER_URL|Y| http://localhost:3001/api|
+|AGENT_ADDRESS|Y|agent1qt8q20p0vsp7y5dkuehwkpmsppvynxv8esg255fwz6el68rftvt5klpyeuj|
+
 ### Endpoints
 
 The endpoints in this repository are:

--- a/README.md
+++ b/README.md
@@ -1,12 +1,83 @@
 # nice-fetch-ai-adapter
 
-The purpose of this repository is to allow interaction between nice-agent-portal (PEER API), Veritable Peer and Cmbridge's 'intelligent agent'.
+The purpose of this repository is to allow interaction between nice-agent-portal (PEER API), Veritable Peer and Cambridge's 'intelligent agent'.
+
+### Endpoints
+
 The endpoints in this repository are:
-| endpoint | usage |
-|----------|----------|
-| "/send-query" | Accepts query from Peer API, forwards it to Sample Agent & then to Veritable Peer. |
-| "/webhooks/drpc"| Accepts posts from veritable Cloudagent and passes them to PeerApi. These are either queries for peerApi or query responses for peer API. |
-| "/receive-response" | This endpoint receives information from chainvine and passes it to Veritable as a response. |
+| endpoint |HTTP Methods| usage |
+|----------|----|----------|
+| "/send-query" |POST| Accepts query from Peer API, forwards it to Sample Agent & then to Veritable Peer. |
+| "/webhooks/drpc"|POST| Accepts posts from veritable Cloudagent and passes them to PeerApi. These are either queries for peerApi or query responses for peer API. |
+| "/receive-response" |POST| This endpoint receives information from chainvine and passes it to Veritable as a response. |
+
+### Payload schemas:
+
+#### POST/send-query schema inbound:
+
+```
+{
+  "jsonrpc": "string",
+  "method": "string",
+  "params": [
+    "string"
+  ],
+  "id": "string"
+}
+```
+
+#### POST/send-query schema outbound:
+
+-> will depend on drcp response
+for now `[202, {}]`
+
+#### POST/webhooks/drpc schema inbound:
+
+- This schema can only include either `response` or `request`.
+- If `request` is present, `role` must be `server` and if `response` is present `role` must be `client`
+
+```
+{
+  "createdAt": "2024-05-23T08:23:49.183Z",
+  "request": {
+    "jsonrpc": "string",
+    "method": "string",
+    "params": [
+      "string"
+    ],
+    "id": "string"
+  },
+  "response": {
+    "jsonrpc": "string",
+    "result": "string",
+    "error": {
+      "code": -32601,
+      "message": "string",
+      "data": "string"
+    },
+    "id": "string"
+  },
+  "connectionId": "string",
+  "role": "client" OR "server",
+  "state": "request-sent",
+  "threadId": "string",
+  "id": "string"
+}
+```
+
+#### POST/webhooks/drpc schema outbound:
+
+-> status 202 request received
+
+#### POST/receive-response schema inbound:
+
+```
+{
+  "jsonrpc": "string",
+  "result": "string",
+  "id": "string"
+}
+```
 
 ### Prerequisites:
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The endpoints in this repository are:
 
 #### POST/send-query schema outbound:
 
--> will depend on drcp response
+-> will depend on drpc response
 for now `[202, {}]`
 
 #### POST/webhooks/drpc schema inbound:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Prerequisits:
+# Prerequisites:
 
 python 3.12 and higher and poetry installed
 
@@ -6,14 +6,10 @@ python 3.12 and higher and poetry installed
 
 Run `poetry install`
 
-Some endpoints require interaction with fetch.ai agent. We have included such `SampleAgent` in this repo. In order to start it(in a new terminal window), please navigate to the `SampleAgent` directory and run: `python sampleAgent.py`. On startup agent prints it's own address -> please include this address in `core/config.py`
+Some endpoints require interaction with fetch.ai agent. We have included such `SampleAgent` in this repo. In order to start it (in a new terminal window), please navigate to the `SampleAgent` directory and run: `python sampleAgent.py`. On startup agent prints it's own address -> please include this address in `core/config.py`
 
-cd into app directory and run `uvicorn main:app ` which starts the app with swagger interface on `http://0.0.0.0:8000/docs`.
+Open new terminal window, cd into app directory and run `uvicorn main:app ` which starts the app with swagger interface on `http://0.0.0.0:8000/docs`.
 
-### To run tests run this:
+### To run tests:
 
 `poetry run pytest -s`
-
-# If I forget to ask:
-
-- atm the agent address is hardcoded in the `agentQuery`. Would it be better if the agent on startup would send it's address to the app or write it into a file from which we'd retrieve it?

--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
-# Prerequisites:
+# nice-fetch-ai-adapter
+
+The purpose of this repository is to allow interaction between nice-agent-portal (PEER API), Veritable Peer and Cmbridge's 'intelligent agent'.
+The endpoints in this repository are:
+| endpoint | usage |
+|----------|----------|
+| "/send-query" | accepts query from Peer API, forwards it to Sample Agent & then to Veritable Peer |
+| "/webhooks/drpc"| accepts posts from veritable Cloudagent and passes them to PeerApi. These are either queries for peerApi or query responses for peer API |
+| "/receive-response" | This endpoint receives information from chainvine and passes it to Veritable as a response |
+
+### Prerequisites:
 
 python 3.12 and higher and poetry installed
 

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ for now `[202, {}]`
 
 Run `poetry install`
 
-Some endpoints require interaction with fetch.ai agent. We have included such `SampleAgent` in this repo. In order to start it (in a new terminal window), please navigate to the `SampleAgent` directory and run: `python sampleAgent.py`. On startup agent prints it's own address -> please include this address in `core/config.py`
-
-Open new terminal window, cd into app directory and run `uvicorn main:app ` which starts the app with swagger interface on `http://0.0.0.0:8000/docs`.
+Some endpoints require interaction with fetch.ai agent. We have included such `SampleAgent` in this repo.
+In order to bring up the repo run `python run.py` from your terminla (in root directory). This will bring up both the Sample fetch.ai agent and our app with swagger interface on `http://0.0.0.0:8000/docs`.
+On startup agent prints it's own address -> please include this address in `core/config.py`(if it is different to the one hardcoded there).
 
 ### To run tests:
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# main
+# Prerequisits:
+
+python 3.12 and higher and poetry installed
+
+### To start the repo
+
+Run `poetry install`
+
+cd into app directory and run `uvicorn main:app ` which starts the app with swagger interface on `http://0.0.0.0:8000/docs`.
+
+Some endpoints require interaction with fetch.ai agent. We have included such `SampleAgent` in this repo. In order to start it(in a new terminal window), please navigate to the `SampleAgent` directory and run: `python sampleAgent.py`
+
+### To run tests run this:
+
+`poetry run pytest -s`
+
+# If I forget to ask:
+
+- atm the agent address is hardcoded in the `agentQuery`. Would it be better if the agent on startup would send it's address to the app or write it into a file from which we'd retrieve it?

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ The endpoints in this repository are:
 
 #### POST/send-query schema inbound:
 
+-> we only support method `query` for now
+
 ```
 {
   "jsonrpc": "string",

--- a/README.md
+++ b/README.md
@@ -19,19 +19,16 @@ The endpoints in this repository are:
 
 ```
 {
-  "jsonrpc": "string",
-  "method": "string",
-  "params": [
-    "string"
-  ],
+  "jsonrpc": "2.0",
+  "method": "query",
+  "params": [{<query json object>}],
   "id": "string"
 }
 ```
 
 #### POST/send-query schema outbound:
 
--> will depend on drpc response
-for now `[202, {}]`
+-> status 202 request received
 
 #### POST/webhooks/drpc schema inbound:
 
@@ -42,22 +39,20 @@ for now `[202, {}]`
 {
   "createdAt": "2024-05-23T08:23:49.183Z",
   "request": {
-    "jsonrpc": "string",
-    "method": "string",
-    "params": [
-      "string"
-    ],
+    "jsonrpc": "2.0",
+    "method": "query",
+    "params": [{<query json object>}],
     "id": "string"
   },
   "response": {
-    "jsonrpc": "string",
-    "result": "string",
+    "jsonrpc": "2.0",
+    "result": {<response json object>},
     "error": {
       "code": -32601,
       "message": "string",
       "data": "string"
     },
-    "id": "string"
+    "id": <must match request.id>
   },
   "connectionId": "string",
   "role": "client" OR "server",
@@ -75,16 +70,21 @@ for now `[202, {}]`
 
 ```
 {
-  "jsonrpc": "string",
-  "result": "string",
-  "error": {
+  jsonrpc: '2.0',
+  result: {<response json object>},
+  id: <must match request.id>
+    "error": {
     "code": -32601,
     "message": "string",
     "data": "string"
   },
-  "id": "string"
 }
+
 ```
+
+#### POST/receive-response schema outbound:
+
+-> status 202 request received
 
 ### Prerequisites:
 
@@ -96,7 +96,7 @@ for now `[202, {}]`
 Run `poetry install`
 
 Some endpoints require interaction with fetch.ai agent. We have included such `SampleAgent` in this repo.
-In order to bring up the repo run `python run.py` from your terminla (in root directory). This will bring up both the Sample fetch.ai agent and our app with swagger interface on `http://0.0.0.0:8000/docs`.
+In order to bring up the repo run `python run.py` from your terminal (in root directory). This will bring up both the Sample fetch.ai agent and our app with swagger interface on `http://0.0.0.0:8000/docs`.
 On startup agent prints it's own address -> please include this address in `core/config.py`(if it is different to the one hardcoded there).
 
 ### To run tests:

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -6,7 +6,10 @@ from pydantic import BaseSettings
 class AppSettings(BaseSettings):
     VERITABLE_URL: str = os.getenv("VERITABLE_URL", "http://localhost:3010")
     PEER_URL: str = os.getenv("PEER_URL", "http://localhost:3001/api")
-    AGENT_ADDRESS: str = os.getenv("AGENT_ADDRESS", "agent1qt8q20p0vsp7y5dkuehwkpmsppvynxv8esg255fwz6el68rftvt5klpyeuj")
+    AGENT_ADDRESS: str = os.getenv(
+        "AGENT_ADDRESS",
+        "agent1qt8q20p0vsp7y5dkuehwkpmsppvynxv8esg255fwz6el68rftvt5klpyeuj",
+    )
 
 
 settings = AppSettings()

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -6,6 +6,7 @@ from pydantic import BaseSettings
 class AppSettings(BaseSettings):
     VERITABLE_URL: str = os.getenv("VERITABLE_URL", "http://localhost:3010")
     PEER_URL: str = os.getenv("PEER_URL", "http://localhost:3001/api")
+    AGENT_ADDRESS: str = os.getenv("AGENT_ADDRESS", "agent1qt8q20p0vsp7y5dkuehwkpmsppvynxv8esg255fwz6el68rftvt5klpyeuj")
 
 
 settings = AppSettings()

--- a/app/routes/posts.py
+++ b/app/routes/posts.py
@@ -16,6 +16,7 @@ from uagents.query import query
 
 veritableUrl = settings.VERITABLE_URL
 peerUrl = settings.PEER_URL
+AGENT_ADDRESS = settings.AGENT_ADDRESS
 
 # class QueryFromPeerApi(Model):
 #     message:dict
@@ -91,7 +92,6 @@ class DrpcEvent(Model):
 
 router = APIRouter()
 
-AGENT_ADDRESS = "agent1qt8q20p0vsp7y5dkuehwkpmsppvynxv8esg255fwz6el68rftvt5klpyeuj"
 
 
 async def agent_query(req):

--- a/app/routes/posts.py
+++ b/app/routes/posts.py
@@ -20,11 +20,13 @@ peerUrl = settings.PEER_URL
 # class QueryFromPeerApi(Model):
 #     message:dict
 
-class DrcpQueryFromPeerApi(Model): 
-  jsonrpc: str
-  method: str = Field(default="query", const=True)
-  params: List[Any]
-  id: Union[str, UUID]
+
+class DrcpQueryFromPeerApi(Model):
+    jsonrpc: str
+    method: str = Field(default="query", const=True)
+    params: List[Any]
+    id: Union[str, UUID]
+
 
 class DrpcRequestObject(Model):
     jsonrpc: str
@@ -70,9 +72,9 @@ class DrpcState(StrEnum):
 # --> {"jsonrpc": "2.0", "method": "subtract", "params": [23, 42], "id": 2}
 # <-- {"jsonrpc": "2.0", "result": -19, "id": 2}
 class DrpcResponseForVeritableApi(Model):
-  jsonrpc: str
-  result: Any
-  id: Union[str, UUID]
+    jsonrpc: str
+    result: Any
+    id: Union[str, UUID]
 
 
 class DrpcEvent(Model):
@@ -89,7 +91,9 @@ class DrpcEvent(Model):
 
 router = APIRouter()
 
-AGENT_ADDRESS = 'agent1qt8q20p0vsp7y5dkuehwkpmsppvynxv8esg255fwz6el68rftvt5klpyeuj'
+AGENT_ADDRESS = "agent1qt8q20p0vsp7y5dkuehwkpmsppvynxv8esg255fwz6el68rftvt5klpyeuj"
+
+
 async def agent_query(req):
     response = await query(destination=AGENT_ADDRESS, message=req, timeout=15.0)
     data = json.loads(response.decode_payload())
@@ -119,15 +123,18 @@ async def peerReceivesQuery(req: DrpcEvent) -> JSONResponse:
         response = await client.post(f"{peerUrl}/receive-query", json=req)
         return [response.status, response.json()]
 
-# Query from PeerApi to query agent & veritable 
+
+# Query from PeerApi to query agent & veritable
 @router.post("/send-query", name="test-name", status_code=202)
-async def send_query(req: DrcpQueryFromPeerApi):  
+async def send_query(req: DrcpQueryFromPeerApi):
     try:
         agentQueryResp = await agent_query(req)
-        expected_response = [{'Successful query response from the Sample Agent'}]
+        expected_response = [{"Successful query response from the Sample Agent"}]
         if agentQueryResp != expected_response:
-            raise ValueError(f"Query Agent returned unexpected response. Response returned: {agentQueryResp}")
-        #do sth based on the agentQueryResponse?? 
+            raise ValueError(
+                f"Query Agent returned unexpected response. Response returned: {agentQueryResp}"
+            )
+        # do sth based on the agentQueryResponse??
         response = await postToVeritable(req)
         if response[0] != "202":
             raise ValueError("Response status is not 202")

--- a/app/routes/posts.py
+++ b/app/routes/posts.py
@@ -93,7 +93,6 @@ class DrpcEvent(Model):
 router = APIRouter()
 
 
-
 async def agent_query(req):
     response = await query(destination=AGENT_ADDRESS, message=req, timeout=15.0)
     data = json.loads(response.decode_payload())

--- a/app/routes/posts.py
+++ b/app/routes/posts.py
@@ -5,8 +5,6 @@ from typing import Any, List, Optional, Union
 from uuid import UUID
 
 import httpx
-
-# from agentQuery.agentQuery import agent_query
 from core.config import settings
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import JSONResponse
@@ -17,9 +15,6 @@ from uagents.query import query
 veritableUrl = settings.VERITABLE_URL
 peerUrl = settings.PEER_URL
 AGENT_ADDRESS = settings.AGENT_ADDRESS
-
-# class QueryFromPeerApi(Model):
-#     message:dict
 
 
 class DrcpQueryFromPeerApi(Model):
@@ -69,9 +64,6 @@ class DrpcState(StrEnum):
     Completed = ("completed",)
 
 
-# RPC Response example
-# --> {"jsonrpc": "2.0", "method": "subtract", "params": [23, 42], "id": 2}
-# <-- {"jsonrpc": "2.0", "result": -19, "id": 2}
 class DrpcResponseForVeritableApi(Model):
     jsonrpc: str
     result: Any
@@ -142,9 +134,8 @@ async def send_query(req: DrcpQueryFromPeerApi):
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.post(
-    "/webhooks/drpc", name="webhooks-drpc", status_code=200
-)  # from veritable cloudagent to peerAPI
+# from veritable cloudagent to peerAPI
+@router.post("/webhooks/drpc", name="webhooks-drpc", status_code=200)
 async def drpc_event_handler(req: DrpcEvent):
     try:
         req_dict = dict(req)
@@ -181,10 +172,9 @@ async def drpc_event_handler(req: DrpcEvent):
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.post(
-    "/receive-response", name="receive-response", status_code=200
-)  # this receives response from chainvine and it forwards info to veritable
-async def receive_response(resp: DrpcResponseForVeritableApi):  # basic RPC response
+# this receives response from chainvine and it forwards info to veritable
+@router.post("/receive-response", name="receive-response", status_code=200)
+async def receive_response(resp: DrpcResponseForVeritableApi):
     try:
         response = await postResponseToVeritable(resp)
         if response[0] != "200":

--- a/app/routes/posts.py
+++ b/app/routes/posts.py
@@ -76,25 +76,20 @@ router = APIRouter()
 
 
 async def agent_query(req: AgentRequest):
-    print("=========")
-    print(req)
     response = await query(destination=AGENT_ADDRESS, message=req, timeout=15.0)
-    print("-----")
-    print(response)
     data = json.loads(response.decode_payload())
-    print(data)
     return [data]
 
 
 async def postToVeritable(req: DrpcRequestObject) -> JSONResponse:
     async with httpx.AsyncClient() as client:
-        response = await client.post(f"{veritableUrl}/drcp/request", json=req)
+        response = await client.post(f"{veritableUrl}/drpc/request", json=req)
         return [response.status, response.json()]
 
 
 async def postResponseToVeritable(req: DrpcResponseObject) -> JSONResponse:
     async with httpx.AsyncClient() as client:
-        response = await client.post(f"{veritableUrl}/drcp/response", json=req)
+        response = await client.post(f"{veritableUrl}/drpc/response", json=req)
         return [response.status, response.json()]
 
 
@@ -139,10 +134,7 @@ async def send_query(req: DrpcRequestObject):
                 )
             )
         agentRequest = AgentRequest(params=req.params, id=str(req.id))
-        print(type(agentRequest))
-        print(type(dict(agentRequest)))
         agentQueryResp = await agent_query(agentRequest)
-        print(agentQueryResp)
         expected_response = [
             {"text": "Successful query response from the Sample Agent"}
         ]
@@ -231,7 +223,7 @@ async def drpc_event_handler(req: DrpcEvent):
                 await create_error_response(
                     id=req.id,
                     error_code=DrpcErrorCode.server_error,
-                    error_message=f"Response status from Peer Api is not 200. Response status: {response[0]} and body: {response[1]}",
+                    error_message=f"Response status from Peer Api is not 200. Response status:{response[0]}, body: {response[1]}",
                 )
             )
         return response
@@ -250,7 +242,7 @@ async def receive_response(resp: DrpcResponseObject):
                 await create_error_response(
                     id=resp.id,
                     error_code=DrpcErrorCode.server_error,
-                    error_message=f"Response status from Peer Api is not 200. Response status: {response[0]} and body: {response[1]}",
+                    error_message=f"Response status from Peer Api is not 200. Response status:{response[0]}, body: {response[1]}",
                 )
             )
         return response

--- a/app/routes/posts.py
+++ b/app/routes/posts.py
@@ -65,12 +65,14 @@ class DrpcEvent(Model):
     threadId: str
     id: str
     _tags: dict
-
+class AgentRequest(Model):
+    params: List[str]
+    id: str
 
 router = APIRouter()
 
 
-async def agent_query(req):
+async def agent_query(req:AgentRequest):
     response = await query(destination=AGENT_ADDRESS, message=req, timeout=15.0)
     data = json.loads(response.decode_payload())
     return [data]
@@ -104,7 +106,10 @@ async def peerReceivesQuery(req: DrpcEvent) -> JSONResponse:
 @router.post("/send-query", name="test-name", status_code=202)
 async def send_query(req: DrpcRequestObject):
     try:
-        agentQueryResp = await agent_query(req)
+        print(req)
+        agentRequest: AgentRequest = {"params": req.params, "id": req.id}
+        agentQueryResp = await agent_query(agentRequest)
+        print(agentQueryResp)
         expected_response = [{"text":"Successful query response from the Sample Agent"}]
         if agentQueryResp != expected_response:
             raise ValueError(

--- a/run.py
+++ b/run.py
@@ -7,11 +7,25 @@ import time
 
 def start_uvicorn():
     os.chdir("app")
-    return subprocess.Popen([sys.executable, "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"])
+    return subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "main:app",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "8000",
+            "--reload",
+        ]
+    )
+
 
 def start_fetch_agent():
     os.chdir("..")
     return subprocess.Popen([sys.executable, "sampleAgent/sampleAgent.py"])
+
 
 def main():
     # Start Uvicorn server
@@ -25,7 +39,7 @@ def main():
 
     # Handle termination signals to gracefully shut down both processes
     def signal_handler(sig, frame):
-        print('Terminating processes...')
+        print("Terminating processes...")
         uvicorn_process.terminate()
         fetch_agent_process.terminate()
         sys.exit(0)
@@ -36,6 +50,7 @@ def main():
     # Wait for processes to complete
     uvicorn_process.wait()
     fetch_agent_process.wait()
+
 
 if __name__ == "__main__":
     main()

--- a/run.py
+++ b/run.py
@@ -1,0 +1,41 @@
+import os
+import signal
+import subprocess
+import sys
+import time
+
+
+def start_uvicorn():
+    os.chdir("app")
+    return subprocess.Popen([sys.executable, "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"])
+
+def start_fetch_agent():
+    os.chdir("..")
+    return subprocess.Popen([sys.executable, "sampleAgent/sampleAgent.py"])
+
+def main():
+    # Start Uvicorn server
+    uvicorn_process = start_uvicorn()
+    print("Uvicorn server started.")
+    time.sleep(5)
+
+    # Start Fetch.ai agent
+    fetch_agent_process = start_fetch_agent()
+    print("Fetch.ai agent started.")
+
+    # Handle termination signals to gracefully shut down both processes
+    def signal_handler(sig, frame):
+        print('Terminating processes...')
+        uvicorn_process.terminate()
+        fetch_agent_process.terminate()
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    # Wait for processes to complete
+    uvicorn_process.wait()
+    fetch_agent_process.wait()
+
+if __name__ == "__main__":
+    main()

--- a/sampleAgent/sampleAgent.py
+++ b/sampleAgent/sampleAgent.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from uagents import Agent, Context, Model
 from uagents.setup import fund_agent_if_low
@@ -7,6 +7,11 @@ from uagents.setup import fund_agent_if_low
 class TestRequest(Model):
     message: str
 
+class DrpcRequestObject(Model):
+    jsonrpc: str
+    method: str
+    params: Optional[List | object]
+    id: str | int
 
 class AgentRequest(Model):
     params: List[str]
@@ -43,6 +48,7 @@ async def query_handler(ctx: Context, sender: str, _query: TestRequest):
     try:
         # do something here with the _query
         ctx.logger.info(_query)
+        print("in agent")
         await ctx.send(
             sender, Response(text="Successful query response from the Sample Agent")
         )

--- a/sampleAgent/sampleAgent.py
+++ b/sampleAgent/sampleAgent.py
@@ -9,18 +9,21 @@ from uagents.setup import fund_agent_if_low
 class TestRequest(Model):
     message: str
 
-class DrcpQueryFromPeerApi(Model): 
-  jsonrpc: str
-  method: str = Field(default="query", const=True)
-  params: List[Any]
-  id: Union[str, UUID]
- 
+
+class DrcpQueryFromPeerApi(Model):
+    jsonrpc: str
+    method: str = Field(default="query", const=True)
+    params: List[Any]
+    id: Union[str, UUID]
+
+
 class Response(Model):
     text: str
 
+
 # test info:
-    # agent address: agent1qt8q20p0vsp7y5dkuehwkpmsppvynxv8esg255fwz6el68rftvt5klpyeuj
-    # agent wallet address: fetch1dc5s9wmerlsvdq9gxp76xxldk8jzp8l9zlyakr
+# agent address: agent1qt8q20p0vsp7y5dkuehwkpmsppvynxv8esg255fwz6el68rftvt5klpyeuj
+# agent wallet address: fetch1dc5s9wmerlsvdq9gxp76xxldk8jzp8l9zlyakr
 agent = Agent(
     name="sample_agent_name",
     seed="sample_agent_seed",
@@ -29,13 +32,14 @@ agent = Agent(
 )
 fund_agent_if_low(agent.wallet.address())
 
- 
+
 @agent.on_event("startup")
 async def startup(ctx: Context):
     ctx.logger.info(f"Starting up {agent.name}")
     ctx.logger.info(f"With address: {agent.address}")
     ctx.logger.info(f"And wallet address: {agent.wallet.address()}")
- 
+
+
 # query from PeerAPI
 @agent.on_query(model=DrcpQueryFromPeerApi, replies={Response})
 async def query_handler(ctx: Context, sender: str, _query: TestRequest):
@@ -43,8 +47,11 @@ async def query_handler(ctx: Context, sender: str, _query: TestRequest):
     try:
         # do something here with the _query
         ctx.logger.info(_query)
-        await ctx.send(sender, Response(text="Successful query response from the Sample Agent"))
+        await ctx.send(
+            sender, Response(text="Successful query response from the Sample Agent")
+        )
     except Exception:
         await ctx.send(sender, Response(text="fail"))
- 
+
+
 agent.run()

--- a/sampleAgent/sampleAgent.py
+++ b/sampleAgent/sampleAgent.py
@@ -7,11 +7,13 @@ from uagents.setup import fund_agent_if_low
 class TestRequest(Model):
     message: str
 
+
 class DrpcRequestObject(Model):
     jsonrpc: str
     method: str
     params: Optional[List | object]
     id: str | int
+
 
 class AgentRequest(Model):
     params: List[str]
@@ -48,7 +50,6 @@ async def query_handler(ctx: Context, sender: str, _query: TestRequest):
     try:
         # do something here with the _query
         ctx.logger.info(_query)
-        print("in agent")
         await ctx.send(
             sender, Response(text="Successful query response from the Sample Agent")
         )

--- a/sampleAgent/sampleAgent.py
+++ b/sampleAgent/sampleAgent.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List
 
 from uagents import Agent, Context, Model
 from uagents.setup import fund_agent_if_low
@@ -8,11 +8,9 @@ class TestRequest(Model):
     message: str
 
 
-class DrpcRequestObject(Model):
-    jsonrpc: str
-    method: str
-    params: Optional[List | object]
-    id: str | int
+class AgentRequest(Model):
+    params: List[str]
+    id: str
 
 
 class Response(Model):
@@ -39,7 +37,7 @@ async def startup(ctx: Context):
 
 
 # query from PeerAPI
-@agent.on_query(model=DrpcRequestObject, replies={Response})
+@agent.on_query(model=AgentRequest, replies={Response})
 async def query_handler(ctx: Context, sender: str, _query: TestRequest):
     ctx.logger.info("Query received by the Sample Agent")
     try:

--- a/sampleAgent/sampleAgent.py
+++ b/sampleAgent/sampleAgent.py
@@ -1,0 +1,50 @@
+from typing import Any, List, Union
+from uuid import UUID
+
+from pydantic import Field
+from uagents import Agent, Context, Model
+from uagents.setup import fund_agent_if_low
+
+
+class TestRequest(Model):
+    message: str
+
+class DrcpQueryFromPeerApi(Model): 
+  jsonrpc: str
+  method: str = Field(default="query", const=True)
+  params: List[Any]
+  id: Union[str, UUID]
+ 
+class Response(Model):
+    text: str
+
+# test info:
+    # agent address: agent1qt8q20p0vsp7y5dkuehwkpmsppvynxv8esg255fwz6el68rftvt5klpyeuj
+    # agent wallet address: fetch1dc5s9wmerlsvdq9gxp76xxldk8jzp8l9zlyakr
+agent = Agent(
+    name="sample_agent_name",
+    seed="sample_agent_seed",
+    port=8001,
+    endpoint="http://localhost:8001/submit",
+)
+fund_agent_if_low(agent.wallet.address())
+
+ 
+@agent.on_event("startup")
+async def startup(ctx: Context):
+    ctx.logger.info(f"Starting up {agent.name}")
+    ctx.logger.info(f"With address: {agent.address}")
+    ctx.logger.info(f"And wallet address: {agent.wallet.address()}")
+ 
+# query from PeerAPI
+@agent.on_query(model=DrcpQueryFromPeerApi, replies={Response})
+async def query_handler(ctx: Context, sender: str, _query: TestRequest):
+    ctx.logger.info("Query received by the Sample Agent")
+    try:
+        # do something here with the _query
+        ctx.logger.info(_query)
+        await ctx.send(sender, Response(text="Successful query response from the Sample Agent"))
+    except Exception:
+        await ctx.send(sender, Response(text="fail"))
+ 
+agent.run()

--- a/sampleAgent/sampleAgent.py
+++ b/sampleAgent/sampleAgent.py
@@ -14,7 +14,7 @@ class DrcpQueryFromPeerApi(Model):
     jsonrpc: str
     method: str = Field(default="query", const=True)
     params: List[Any]
-    id: Union[str, UUID]
+    id: str | int
 
 
 class Response(Model):

--- a/sampleAgent/sampleAgent.py
+++ b/sampleAgent/sampleAgent.py
@@ -1,7 +1,5 @@
-from typing import Any, List, Union
-from uuid import UUID
+from typing import List, Optional
 
-from pydantic import Field
 from uagents import Agent, Context, Model
 from uagents.setup import fund_agent_if_low
 
@@ -10,10 +8,10 @@ class TestRequest(Model):
     message: str
 
 
-class DrcpQueryFromPeerApi(Model):
+class DrpcRequestObject(Model):
     jsonrpc: str
-    method: str = Field(default="query", const=True)
-    params: List[Any]
+    method: str
+    params: Optional[List | object]
     id: str | int
 
 
@@ -41,7 +39,7 @@ async def startup(ctx: Context):
 
 
 # query from PeerAPI
-@agent.on_query(model=DrcpQueryFromPeerApi, replies={Response})
+@agent.on_query(model=DrpcRequestObject, replies={Response})
 async def query_handler(ctx: Context, sender: str, _query: TestRequest):
     ctx.logger.info("Query received by the Sample Agent")
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,17 @@ def test_post_query_success_mock_202(mocker) -> None:
             {},
         ],
     )
+@pytest.fixture
+def test_agent_query_mock(mocker) -> None:
+    """
+    Test return data for the 202 response fromquery agent.
+    """
+    mocker.patch(
+        "routes.posts.agent_query",
+        return_value=[
+            {"Successful query response from the Sample Agent"},
+        ],
+    )
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,7 @@ def test_agent_query_mock(mocker) -> None:
     mocker.patch(
         "routes.posts.agent_query",
         return_value=[
-            {"Successful query response from the Sample Agent"},
+            {"text":"Successful query response from the Sample Agent"},
         ],
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,7 @@ def test_agent_query_mock(mocker) -> None:
     mocker.patch(
         "routes.posts.agent_query",
         return_value=[
-            {"text":"Successful query response from the Sample Agent"},
+            {"text": "Successful query response from the Sample Agent"},
         ],
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,8 @@ def test_post_query_success_mock_202(mocker) -> None:
             {},
         ],
     )
+
+
 @pytest.fixture
 def test_agent_query_mock(mocker) -> None:
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,7 +85,7 @@ def test_receive_response_fail_mock_500(mocker) -> None:
 
 
 @pytest.fixture
-def test_drcp_event_handler_response_success_mock_200(mocker) -> None:
+def test_drpc_event_handler_response_success_mock_200(mocker) -> None:
     """
     Test return data for forwarding data from the "/webhooks/drpc" endpoint to /receive-response endpoint in peerAPI.
     """
@@ -99,7 +99,7 @@ def test_drcp_event_handler_response_success_mock_200(mocker) -> None:
 
 
 @pytest.fixture
-def test_drcp_event_handler_query_success_mock_200(mocker) -> None:
+def test_drpc_event_handler_query_success_mock_200(mocker) -> None:
     """
     Test return data for forwarding data from the "/webhooks/drpc" endpoint to /receive-query endpoint in peerAPI.
     """
@@ -113,7 +113,7 @@ def test_drcp_event_handler_query_success_mock_200(mocker) -> None:
 
 
 @pytest.fixture
-def test_drcp_event_handler_query_fail_mock_500(mocker) -> None:
+def test_drpc_event_handler_query_fail_mock_500(mocker) -> None:
     """
     Test failed return data for forwarding data from the "/webhooks/drpc" endpoint to /receive-query endpoint in peerAPI.
     """

--- a/tests/test_drcp_event_handler.py
+++ b/tests/test_drcp_event_handler.py
@@ -6,10 +6,10 @@ pytestmark = pytest.mark.asyncio
 
 
 # happy path tests
-async def test_drcp_event_handler_response(
+async def test_drpc_event_handler_response(
     app: FastAPI,
     client: AsyncClient,
-    test_drcp_event_handler_response_success_mock_200,
+    test_drpc_event_handler_response_success_mock_200,
 ) -> None:
     """
     ...
@@ -35,10 +35,10 @@ async def test_drcp_event_handler_response(
     assert response_pat.status_code == status.HTTP_200_OK
 
 
-async def test_drcp_event_handler_query(
+async def test_drpc_event_handler_query(
     app: FastAPI,
     client: AsyncClient,
-    test_drcp_event_handler_query_success_mock_200,
+    test_drpc_event_handler_query_success_mock_200,
 ) -> None:
     """
     ...
@@ -114,7 +114,7 @@ async def test_receive_response_500(
     assert response_pat.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
 
 
-async def test_drcp_event_handler_query_wrong_role(
+async def test_drpc_event_handler_query_wrong_role(
     app: FastAPI,
     client: AsyncClient,
 ) -> None:
@@ -142,7 +142,7 @@ async def test_drcp_event_handler_query_wrong_role(
     assert response_pat.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
 
 
-async def test_drcp_event_handler_response_wrong_role(
+async def test_drpc_event_handler_response_wrong_role(
     app: FastAPI,
     client: AsyncClient,
 ) -> None:
@@ -170,10 +170,10 @@ async def test_drcp_event_handler_response_wrong_role(
     assert response_pat.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
 
 
-async def test_drcp_event_handler_query_fail_500(
+async def test_drpc_event_handler_query_fail_500(
     app: FastAPI,
     client: AsyncClient,
-    test_drcp_event_handler_query_fail_mock_500,
+    test_drpc_event_handler_query_fail_mock_500,
 ) -> None:
     """
     ...

--- a/tests/test_post_query.py
+++ b/tests/test_post_query.py
@@ -10,11 +10,19 @@ async def test_post_query(
     app: FastAPI,
     client: AsyncClient,
     test_post_query_success_mock_202,
+    test_agent_query_mock,
 ) -> None:
     """
     ...
     """
-    payload = {"message": {"content": "some test message"}}
+    payload = {
+  "jsonrpc": "string",
+  "method": "query",
+  "params": [
+    "string"
+  ],
+  "id": "string"
+}
     response_pat = await client.post(
         app.url_path_for("test-name"),
         json=payload,
@@ -23,8 +31,6 @@ async def test_post_query(
 
 
 # sad path tests
-
-
 async def test_post_query_wrong_body(
     app: FastAPI,
     client: AsyncClient,
@@ -48,7 +54,14 @@ async def test_post_query_failed_500(
     """
     ...
     """
-    payload = {"message": {"content": "some test message"}}
+    payload = {
+  "jsonrpc": "string",
+  "method": "query",
+  "params": [
+    "string"
+  ],
+  "id": "string"
+}
     response_pat = await client.post(
         app.url_path_for("test-name"),
         json=payload,

--- a/tests/test_post_query.py
+++ b/tests/test_post_query.py
@@ -16,13 +16,11 @@ async def test_post_query(
     ...
     """
     payload = {
-  "jsonrpc": "string",
-  "method": "query",
-  "params": [
-    "string"
-  ],
-  "id": "string"
-}
+        "jsonrpc": "string",
+        "method": "query",
+        "params": ["string"],
+        "id": "string",
+    }
     response_pat = await client.post(
         app.url_path_for("test-name"),
         json=payload,
@@ -55,13 +53,11 @@ async def test_post_query_failed_500(
     ...
     """
     payload = {
-  "jsonrpc": "string",
-  "method": "query",
-  "params": [
-    "string"
-  ],
-  "id": "string"
-}
+        "jsonrpc": "string",
+        "method": "query",
+        "params": ["string"],
+        "id": "string",
+    }
     response_pat = await client.post(
         app.url_path_for("test-name"),
         json=payload,

--- a/tests/test_receive_response.py
+++ b/tests/test_receive_response.py
@@ -16,7 +16,11 @@ async def test_receive_response(
     """
     ...
     """
-    payload = {"message": {"content": "some test message"}}
+    payload = {
+  "jsonrpc": "string",
+  "result": "string",
+  "id": "string"
+}
     response_pat = await client.post(
         app.url_path_for("receive-response"),
         json=payload,
@@ -35,7 +39,11 @@ async def test_receive_response_fail_500(
     """
     ...
     """
-    payload = {"message": {"content": "some test message"}}
+    payload = {
+  "jsonrpc": "string",
+  "result": "string",
+  "id": "string"
+}
     response_pat = await client.post(
         app.url_path_for("receive-response"),
         json=payload,

--- a/tests/test_receive_response.py
+++ b/tests/test_receive_response.py
@@ -16,11 +16,7 @@ async def test_receive_response(
     """
     ...
     """
-    payload = {
-  "jsonrpc": "string",
-  "result": "string",
-  "id": "string"
-}
+    payload = {"jsonrpc": "string", "result": "string", "id": "string"}
     response_pat = await client.post(
         app.url_path_for("receive-response"),
         json=payload,
@@ -39,11 +35,7 @@ async def test_receive_response_fail_500(
     """
     ...
     """
-    payload = {
-  "jsonrpc": "string",
-  "result": "string",
-  "id": "string"
-}
+    payload = {"jsonrpc": "string", "result": "string", "id": "string"}
     response_pat = await client.post(
         app.url_path_for("receive-response"),
         json=payload,


### PR DESCRIPTION
# Pull Request

## Checklist

- [ ] Have you read nice-fetch-ai-adapter's Code of Conduct? https://github.com/digicatapult/nice-fetch-ai-adapter/.github/blob/main/CODE_OF_CONDUCT.md
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Feature
- [ ] Documentation Update

## Linked tickets

- https://digicatapult.atlassian.net/browse/VR-40

## High level description

Added a fetch.ai sample agent to the repository. Added schemas for DRPC request and response to relevant endpoints. 

## Detailed description

fetch.ai sample agent has been added to the repository to demonstrate our ability to forward queries received on an endpoint (in particular `/send-query` endpoint). The query can be forwarded to a Sample Agent from where we would have the ability to communicate with other fetch.ai agents registered on almanach. 

## Describe alternatives you've considered

We have considered making the Sample Agent a separate repository, but following the fetch.ai's example [here](https://fetch.ai/docs/examples/on-query-proxy) we have decided that a simple Sample Agent can exist in the same repository.

## Operational impact

<!--- A description of any operational considerations associated with the change. Is there anything in particular we should be looking at when deploying the change to make sure it is working as intended. If something goes wrong will any special actions be needed to revert the change. -->

## Additional context

At the moment the AGENT_ADDRESS is obtained upon startup on the agent and included in config.py
